### PR TITLE
Changed raw github for a real CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Tesseract.js works with a `<script>` tag via local copy or cdn, with webpack and
 
 You can simply include Tesseract.js with a cdn like this:
 ```html
-<script src='https://cdn.rawgit.com/naptha/tesseract.js/0.2.0/dist/tesseract.js'></script>
+<script src='https://unpkg.com/tesseract.js@1/dist/tesseract.js'></script>
 ```
 
 After including your scripts, the `Tesseract` variable should be defined! You can [head to the docs](#docs) for a full treatment of the API.


### PR DESCRIPTION
Raw github is not supposed to be a CDN [and it has some problems](http://stackoverflow.com/questions/7180099/including-js-from-raw-github-com). So I changed the url to unpkg.com which is a CDN for projects that are released on NPM.