### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ result is: {
 
 ### TesseractJob.catch(callback: function) -> TesseractJob
 Sets `callback` as the function that will be called if the job fails. 
-- `callback` is a function with the signature `callback(error)` where `error` is a json object.
+- `callback` is a function with the signature `callback(error)` where `error` is a json object. 
 
 ## Local Installation
 

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ result is: {
 
 ### TesseractJob.catch(callback: function) -> TesseractJob
 Sets `callback` as the function that will be called if the job fails. 
-- `callback` is a function with the signature `callback(erros)` where `error` is a json object.
+- `callback` is a function with the signature `callback(error)` where `error` is a json object.
 
 ## Local Installation
 


### PR DESCRIPTION
Corrected the json object's name from 'erros' to 'error' in line 226 of README.md