### PR TITLE
Fixed typo (extra parentheses)

### DIFF
--- a/src/node/index.js
+++ b/src/node/index.js
@@ -40,7 +40,7 @@ function loadImage(image, cb){
         }).catch(function (err) {
             return console.error(err);
         });
-    })
+    }
 
     if(typeof image === 'string'){
         fs.readFile(image, function(err, buffer){


### PR DESCRIPTION
Typo fixed in node/index.js. The extra parentheses was not needed.
