### PR TITLE
Apache 2.0 license identifier fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "./src/node/index.js": "./src/browser/index.js"
   },
   "author": "",
-  "license": "Apache",
+  "license": "Apache-2.0",
   "devDependencies": {
     "babel-preset-es2015": "^6.16.0",
     "babelify": "^7.3.0",


### PR DESCRIPTION
@bijection super small fix, but npm throws a warning whenever "npm install" runs because the license id is not correct according to it. 

The license specified in this repo is "Apache 2.0", which has the identifier Apache-2.0  https://spdx.org/licenses/ 
