### PR TITLE
fix(webpack/error): create not found error when compiled with webpack

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ const circularize = require('./common/circularize.js')
 const TesseractJob = require('./common/job');
 const version = require('../package.json').version;
 
-function create(workerOptions = {}){
+const create = function(workerOptions = {}){
 	var worker = new TesseractWorker(Object.assign({}, adapter.defaultOptions, workerOptions));
 	worker.create = create;
 	worker.version = version;
@@ -22,7 +22,7 @@ class TesseractWorker {
 		return this._delay(job => {
 			if (typeof options === 'string') options = {lang: options}
 			options.lang = options.lang || 'eng';
-			
+
 			job._send('recognize', { image, options, workerOptions: this.workerOptions });
 		})
 	}
@@ -32,7 +32,7 @@ class TesseractWorker {
 		})
 	}
 
-	terminate(){ 
+	terminate(){
 		if(this.worker) adapter.terminateWorker(this);
 		this.worker = null;
 		this._currentJob = null;


### PR DESCRIPTION
**What**
When bundling the module with Webpack, `create` throws a breaking not defined error. 

**Fix**
By updating the function declaration to be a function expression via the addition of `const`.