### PR TITLE
crush tesseract.js when use is-url@1.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "file-type": "^3.8.0",
     "isomorphic-fetch": "^2.2.1",
-    "is-url": "^1.2.2",
+    "is-url": "1.2.2",
     "jpeg-js": "^0.2.0",
     "level-js": "^2.2.4",
     "node-fetch": "^1.6.3",


### PR DESCRIPTION
fix is-url version 1.2.2

because is-url logic is fully changed.

so, if this library use lately version, occur crushing when app's running time.