### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ First:
 ```
 or
 ```
+> npm init
 > npm install tesseract.js --save
 ```
 > Note: Tesseract.js currently requires Node.js v6.8.0 or higher.


### PR DESCRIPTION
for installing with npm, npm init must be called first, else it fails. Issue here: #248 