### PR TITLE
Fix security issue with CORS proxy

### DIFF
--- a/src/browser/index.js
+++ b/src/browser/index.js
@@ -52,18 +52,22 @@ function loadImage(image, cb){
             var im = new Image
             im.src = image;
             im.onload = e => loadImage(im, cb);
+            //im.onerror = e => ?; TODO handle error
             return
         }else{
             var xhr = new XMLHttpRequest();
             xhr.open('GET', image, true)
             xhr.responseType = "blob";
-            xhr.onload = e => loadImage(xhr.response, cb);
-            xhr.onerror = function(e){
-                if(/^https?:\/\//.test(image) && !/^https:\/\/crossorigin.me/.test(image)){
-                    console.debug('Attempting to load image with CORS proxy')
-                    loadImage('https://crossorigin.me/' + image, cb)
+            
+            xhr.onload = e => {
+                if (xhr.status >= 400){
+                    //TODO handle error
+                }else{
+                    loadImage(xhr.response, cb);
                 }
-            }
+            };
+            //xhr.onerror = e => ?; TODO handle error
+            
             xhr.send(null)
             return
         }
@@ -71,6 +75,7 @@ function loadImage(image, cb){
         // files
         var fr = new FileReader()
         fr.onload = e => loadImage(fr.result, cb);
+        //fr.onerror = e => ?; TODO handle error
         fr.readAsDataURL(image)
         return
     }else if(image instanceof Blob){


### PR DESCRIPTION
### TL;DR: Error handling is broken when loading an image, how do I forward an error at the `TODO`-comments I placed to the `catch`-callback of the `TesseractJob`?

During my adventures while using Tesseract.js I often had the problem of Tesseract.js failing silently when trying to recognize an image. After digging through the source code I found out that the error handling in this area is so to speak 'incomplete'.
There are 2 `onerror` callbacks missing, and the XHR one for some reason tries to load an image through an external proxy (more on that later). There's also no checking for HTTP status codes, which causes a completely silent fail when something like a 404 happens (this was my problem).

I tried to fix it by having it call the `catch`-callback on the `TesseractJob`, but I couldn't find out how to do that, so for now I have just added `TODO`-comments where the error-handling should be fixed. I'm not creating this PR with the intent of it being merged in it's current state, I'll be glad to fix the error handling myself with the right pointers.

I have also removed the [crossorigin.me](http://crossorigin.me/) proxy. The main reason being security, there's a reason for CORS being prohibited by default. We're also trusting a random proxy with potentially sensitive data, which isn't really a good idea. There are of course valid reasons for using such a proxy, but that decision should be made by the user and not some library they are using.
[crossorigin.me](http://crossorigin.me/) also explicitly states that the proxy is not intended for production use, and as far as I can tell there's no distinction between debug and production in that piece of code.