### PR TITLE
Fix initialization when calling from other Worker

### DIFF
--- a/src/browser/index.js
+++ b/src/browser/index.js
@@ -16,9 +16,11 @@ exports.defaultOptions = defaultOptions;
 
 
 exports.spawnWorker = function spawnWorker(instance, workerOptions){
-    if(window.Blob && window.URL){
-        var blob = new Blob(['importScripts("' + workerOptions.workerPath + '");'])
-        var worker = new Worker(window.URL.createObjectURL(blob));
+    if(Blob && URL){
+        var blob = new Blob(['importScripts("' + workerOptions.workerPath + '");'], {
+            type: 'application/javascript'
+        });
+        var worker = new Worker(URL.createObjectURL(blob));
     }else{
         var worker = new Worker(workerOptions.workerPath)
     }


### PR DESCRIPTION
window global is not defined when Tesseract gets called from another worker.
Also, when blob-type is not defined, it fails with an error like:
'Refused to execute script from 'blob:http://localhost:8080/160d4c2a-...-7af01' because its MIME type ('') is not executable.'