### PR TITLE
Fixed uncaught exceptions in Promise.

### DIFF
--- a/src/common/workerUtils.js
+++ b/src/common/workerUtils.js
@@ -205,24 +205,28 @@ const handleRecognize = ({
           }
         })
         .then(() => {
-          const progressUpdate = (progress) => {
-            res.progress({ status: 'initializing api', progress });
-          };
-          const params = {
-            ...defaultParams,
-            ...customParams,
-          };
-          progressUpdate(0);
-          handleParams(langs, params);
-          progressUpdate(0.5);
-          const ptr = setImage(image);
-          progressUpdate(1);
-          api.Recognize(null);
-          const files = handleOutput(params);
-          const result = dump(TessModule, api, params);
-          api.End();
-          TessModule._free(ptr);
-          res.resolve({ files, ...result });
+          try {
+            const progressUpdate = (progress) => {
+              res.progress({ status: 'initializing api', progress });
+            };
+            const params = {
+              ...defaultParams,
+              ...customParams,
+            };
+            progressUpdate(0);
+            handleParams(langs, params);
+            progressUpdate(0.5);
+            const ptr = setImage(image);
+            progressUpdate(1);
+            api.Recognize(null);
+            const files = handleOutput(params);
+            const result = dump(TessModule, api, params);
+            api.End();
+            TessModule._free(ptr);
+            res.resolve({ files, ...result });
+          } catch (err) {
+            res.reject({ err: err });
+          }
         })
     ))
 );


### PR DESCRIPTION
Hi,

I would like to submit this PR to caught and properly reject by Promise all uncaught exceptions that can occurs during Tesseract-OCR recognition.

In my test case, I have a particular jpg file that crashes Tesseract-OCR, when running via browser on Chrome (75) over Ubuntu 17.10 64bit.

Thanks in advance.
