### PR TITLE
Add unpkg and jsdelivr entries to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "2.0.0-alpha.10",
   "description": "Pure Javascript Multilingual OCR",
   "main": "src/index.js",
+  "unpkg": "dist/tesseract.min.js",
+  "jsdelivr": "dist/tesseract.min.js",
   "scripts": {
     "start": "node scripts/server.js",
     "build": "rimraf dist && webpack --config scripts/webpack.config.prod.js",


### PR DESCRIPTION
This package is so cool! OCR in a browser feels like the future.

This PR adds unpkg and jsdelivr entries to package.json, so folks can refer to a URL like

```
https://unpkg.com/tesseract.js@2
```

And get the UMD build without having to hardcode a path. This also makes tools that load modules with AMD, like d3-require, capable of loading tesseract.js automatically.