### PR TITLE
Make then .then(resolve, reject) API thenable. Fixes #295

### DIFF
--- a/src/common/TesseractJob.js
+++ b/src/common/TesseractJob.js
@@ -48,14 +48,14 @@ class TesseractJob {
    * @param {function} reject - called when the job fails
    */
   then(resolve, reject) {
-    if (this._resolve.push) {
-      this._resolve.push(resolve);
-    } else {
-      resolve(this._resolve);
-    }
-
-    if (reject) this.catch(reject);
-    return this;
+    return new Promise((res, rej) => {
+      if (!this._resolve.push) {
+        res(this._result);
+      } else {
+        this._resolve.push(res);
+      }
+      this.catch(rej);
+    }).then(resolve, reject);
   }
 
   /**


### PR DESCRIPTION
This potentially is just strictly-better than the proposal in #295: it makes the return value of `then()` a proper Promise object, so it respects return values and can be `then()`'ed again. It does change the API of tesseract.js for this method, because the return value of `then()` is no longer `this`.