### PR TITLE
Enhancement

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,5 +1,5 @@
 tasks:
-  - command: gp await-port 3000 && gp preview $(gp url 3000)/examples/browser/demo.html
+  - command: gp await-port 3000 && sleep 3 && gp preview $(gp url 3000)/examples/browser/demo.html
   - init: npm install
     command: npm start
 ports:


### PR DESCRIPTION
Hi! :slightly_smiling_face: ! 
While trying opening this repo with Gitpod a mate of mine noticed that if we click under the ports tab and click open in Browser and append examples/browser/demo.html to the URL we get `Port 3000 didn't respond` and this even though can be resolved simply by refreshing the preview, it would be nicer to wait for the server to be fully ready in order to prevent the error page from showing up. This PR fixes that.
You can give it a try on My Fork https://gitpod.io/#https://github.com/naptha/tesseract.js/blob/master/examples/browser/demo.html