### PR TITLE
Fix typings

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -3,7 +3,7 @@ declare namespace Tesseract {
   function createWorker(options?: Partial<WorkerOptions>): Worker
   function setLogging(logging: boolean): void
   function recognize(image: ImageLike, langs?: string, options?: Partial<WorkerOptions>): Promise<RecognizeResult>
-  function detect(image: ImageLike, options?: Partial<WorkerOptions>)
+  function detect(image: ImageLike, options?: Partial<WorkerOptions>): any
 
   interface Scheduler {
     addWorker(worker: Worker): string
@@ -32,7 +32,7 @@ declare namespace Tesseract {
     cacheMethod: string
     workerBlobURL: boolean
     gzip: boolean
-    logger: (any) => void
+    logger: (arg: any) => void
   }
   interface WorkerParams {
     tessedit_ocr_engine_mode: OEM


### PR DESCRIPTION
This pull request fixed following typing errors:
```bash
node_modules/tesseract.js/src/index.d.ts:6:12 - error TS7010: 'detect', which lacks return-type annotation, implicitly has an 'any' return type.

6   function detect(image: ImageLike, options?: Partial<WorkerOptions>)
             ~~~~~~

node_modules/tesseract.js/src/index.d.ts:35:14 - error TS7051: Parameter has a name but no type. Did you mean 'arg0: any'?

35     logger: (any) => void
                ~~~


Found 2 errors.
```