### PR TITLE
Option for top-level error handler

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -42,6 +42,7 @@ createWorker is a factory function that creates a tesseract worker, a worker is 
   - `workerBlobURL` a boolean to define whether to use Blob URL for worker script, default: true
   - `gzip` a boolean to define whether the traineddata from the remote is gzipped, default: true
   - `logger` a function to log the progress, a quick example is `m => console.log(m)`
+  - `errorHandler` a function to handle worker errors, a quick example is `err => console.error(err)`
 
 
 **Examples:**
@@ -143,17 +144,17 @@ Worker.setParameters() set parameters for Tesseract API (using SetVariable()), i
 
 **Supported Paramters:**
 
-| name | type | default value | description |
-| ---- | ---- | ------------- | ----------- |
-| tessedit\_ocr\_engine\_mode | enum | OEM.DEFAULT | Check [HERE](https://github.com/tesseract-ocr/tesseract/blob/4.0.0/src/ccstruct/publictypes.h#L268) for definition of each mode | 
-| tessedit\_pageseg\_mode | enum | PSM.SINGLE\_BLOCK | Check [HERE](https://github.com/tesseract-ocr/tesseract/blob/4.0.0/src/ccstruct/publictypes.h#L163) for definition of each mode |
-| tessedit\_char\_whitelist | string | '' | setting white list characters makes the result only contains these characters, useful the content in image is limited |
-| preserve\_interword\_spaces | string | '0' | '0' or '1', keeps the space between words |
-| tessjs\_create\_hocr | string | '1' | only 2 values, '0' or '1', when the value is '1', tesseract.js includes hocr in the result |
-| tessjs\_create\_tsv | string | '1' | only 2 values, '0' or '1', when the value is '1', tesseract.js includes tsv in the result |
-| tessjs\_create\_box | string | '0' | only 2 values, '0' or '1', when the value is '1', tesseract.js includes box in the result |
-| tessjs\_create\_unlv | string | '0' | only 2 values, '0' or '1', when the value is '1', tesseract.js includes unlv in the result |
-| tessjs\_create\_osd | string | '0' | only 2 values, '0' or '1', when the value is '1', tesseract.js includes osd in the result |
+| name                        | type   | default value     | description                                                                                                                     |
+| --------------------------- | ------ | ----------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| tessedit\_ocr\_engine\_mode | enum   | OEM.DEFAULT       | Check [HERE](https://github.com/tesseract-ocr/tesseract/blob/4.0.0/src/ccstruct/publictypes.h#L268) for definition of each mode |
+| tessedit\_pageseg\_mode     | enum   | PSM.SINGLE\_BLOCK | Check [HERE](https://github.com/tesseract-ocr/tesseract/blob/4.0.0/src/ccstruct/publictypes.h#L163) for definition of each mode |
+| tessedit\_char\_whitelist   | string | ''                | setting white list characters makes the result only contains these characters, useful the content in image is limited           |
+| preserve\_interword\_spaces | string | '0'               | '0' or '1', keeps the space between words                                                                                       |
+| tessjs\_create\_hocr        | string | '1'               | only 2 values, '0' or '1', when the value is '1', tesseract.js includes hocr in the result                                      |
+| tessjs\_create\_tsv         | string | '1'               | only 2 values, '0' or '1', when the value is '1', tesseract.js includes tsv in the result                                       |
+| tessjs\_create\_box         | string | '0'               | only 2 values, '0' or '1', when the value is '1', tesseract.js includes box in the result                                       |
+| tessjs\_create\_unlv        | string | '0'               | only 2 values, '0' or '1', when the value is '1', tesseract.js includes unlv in the result                                      |
+| tessjs\_create\_osd         | string | '0'               | only 2 values, '0' or '1', when the value is '1', tesseract.js includes osd in the result                                       |
 
 **Examples:**
 

--- a/src/createWorker.js
+++ b/src/createWorker.js
@@ -132,7 +132,6 @@ module.exports = (_options = {}) => {
       resolves[action]({ jobId, data: d });
     } else if (status === 'reject') {
       rejects[action](data);
-      throw Error(data);
     } else if (status === 'progress') {
       logger(data);
     }

--- a/src/createWorker.js
+++ b/src/createWorker.js
@@ -19,6 +19,7 @@ module.exports = (_options = {}) => {
   const id = getId('Worker', workerCounter);
   const {
     logger,
+    errorHandler,
     ...options
   } = resolvePaths({
     ...defaultOptions,
@@ -132,6 +133,11 @@ module.exports = (_options = {}) => {
       resolves[action]({ jobId, data: d });
     } else if (status === 'reject') {
       rejects[action](data);
+      if (errorHandler) {
+        errorHandler(data);
+      } else {
+        throw Error(data);
+      }
     } else if (status === 'progress') {
       logger(data);
     }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -32,7 +32,8 @@ declare namespace Tesseract {
     cacheMethod: string
     workerBlobURL: boolean
     gzip: boolean
-    logger: (arg: any) => void
+    logger: (arg: any) => void,
+    errorHandler: (arg: any) => void
   }
   interface WorkerParams {
     tessedit_ocr_engine_mode: OEM


### PR DESCRIPTION
This PR offers a workaround to #367 by letting the client code install an optional error handler.

This fixes the issue without breaking previous behavior.

This would allow handling an error at the top level, for example, when using a Scheduler where all `createWorker` calls are done in advance.