### PR TITLE
Enable Firefox extesions too

### DIFF
--- a/src/worker-script/index.js
+++ b/src/worker-script/index.js
@@ -89,7 +89,7 @@ const loadLanguage = async ({
       if (typeof _lang === 'string') {
         let path = null;
 
-        if (isURL(langPath) || langPath.startsWith('chrome-extension://') || langPath.startsWith('file://')) { /** When langPath is an URL */
+        if (isURL(langPath) || langPath.startsWith('moz-extension://') || langPath.startsWith('chrome-extension://') || langPath.startsWith('file://')) { /** When langPath is an URL */
           path = langPath;
         }
 


### PR DESCRIPTION
AFAIK this library has no particular reason to ditch Firefox extensions. I have tested with above changes applied and I can finally use OCR within Firefox extensions too.

Thanks for considering this change.