### PR TITLE
Fix displaying recognized text in demo example

### DIFF
--- a/examples/browser/demo.html
+++ b/examples/browser/demo.html
@@ -27,7 +27,7 @@ function progressUpdate(packet){
 
 		if(packet.status == 'done'){
 			var pre = document.createElement('pre')
-			pre.appendChild(document.createTextNode(packet.data.text))
+			pre.appendChild(document.createTextNode(packet.data.data.text))
 			line.innerHTML = ''
 			line.appendChild(pre)
 


### PR DESCRIPTION
There was an issue with accessing the `text` property from packet object.

It actually lives in `packet.data.data.text` and not `packet.data.text`

Before (notice the `undefined` in the box):
![image](https://user-images.githubusercontent.com/17815179/71812369-51cf4100-3077-11ea-88c0-e0268e9a791f.png)

After:
![image](https://user-images.githubusercontent.com/17815179/71812394-5e539980-3077-11ea-805f-a4abfdb50d9d.png)

