### PR TITLE
Removed redirects in links to core tesseract documentation

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -9,9 +9,9 @@ During the downloading of language model, Tesseract.js will first check if \*.tr
 
 ## How can I train my own \*.traineddata?
 
-For tesseract.js v2, check [TrainingTesseract 4.00](https://github.com/tesseract-ocr/tesseract/wiki/TrainingTesseract-4.00)
+For tesseract.js v2, check [TrainingTesseract 4.00](https://tesseract-ocr.github.io/tessdoc/TrainingTesseract-4.00)
 
-For tesseract.js v1, check [Training Tesseract 3.03–3.05](https://github.com/tesseract-ocr/tesseract/wiki/Training-Tesseract-3.03%E2%80%933.05)
+For tesseract.js v1, check [Training Tesseract 3.03–3.05](https://tesseract-ocr.github.io/tessdoc/Training-Tesseract-3.03%E2%80%933.05)
 
 ## How can I get HOCR, TSV, Box, UNLV, OSD?
 

--- a/docs/tesseract_lang_list.md
+++ b/docs/tesseract_lang_list.md
@@ -1,3 +1,3 @@
 # Tesseract Languages
 
-Please check [HERE](https://github.com/tesseract-ocr/tesseract/wiki/Data-Files#data-files-for-version-400-november-29-2016) for supported languages
+Please check [HERE](https://tesseract-ocr.github.io/tessdoc/Data-Files#data-files-for-version-400-november-29-2016) for supported languages


### PR DESCRIPTION
The main tesseract project has moved away from github wiki documentation.
Some links in this repo still refer to the old wiki links.

With i.e. the supported languages link, the user can still navigate to the new Data-Files documentation page manually, but the fragment id is lost along the way so they're not pointed to the right part of the page.