### PR TITLE
Modified logger to have the userJobId

### DIFF
--- a/src/createWorker.js
+++ b/src/createWorker.js
@@ -173,7 +173,7 @@ module.exports = (_options = {}) => {
         throw Error(data);
       }
     } else if (status === 'progress') {
-      logger(data);
+      logger({...data, 'userJobId': jobId});
     }
   });
 

--- a/src/createWorker.js
+++ b/src/createWorker.js
@@ -173,7 +173,7 @@ module.exports = (_options = {}) => {
         throw Error(data);
       }
     } else if (status === 'progress') {
-      logger({...data, 'userJobId': jobId});
+      logger({ ...data, userJobId: jobId });
     }
   });
 


### PR DESCRIPTION
Internally the log can provide the name of the added job, but with the logger I don't have access to that information. I added an extra parameter to be able to take the name and use the logger to show information about the job that's being processed. 
I'm open to modifying this to fulfil any requirement, just let me know what's needed. 
It's my first time doing this so sorry if I made any mistake. 
Hope it can help on #399 but I think to fix it a better definition is needed. 