### PR TITLE
Fixed method for selecting env type

### DIFF
--- a/src/utils/getEnvironment.js
+++ b/src/utils/getEnvironment.js
@@ -5,10 +5,10 @@ module.exports = (key) => {
 
   if (typeof WorkerGlobalScope !== 'undefined') {
     env.type = 'webworker';
-  } else if (typeof window === 'object') {
-    env.type = 'browser';
   } else if (isElectron()) {
     env.type = 'electron';
+  } else if (typeof window === 'object') {
+    env.type = 'browser';
   } else if (typeof process === 'object' && typeof require === 'function') {
     env.type = 'node';
   }


### PR DESCRIPTION
This change fixes that issue: #497. Electron-vue application have a 'window' object, but tesseract.js uses a 'node' worker. This creates confusion in the paths.