### PR TITLE
Fix Failed to execute 'toBlob' on 'HTMLCanvasElement'  when load cross site image

### DIFF
--- a/src/worker/browser/loadImage.js
+++ b/src/worker/browser/loadImage.js
@@ -29,6 +29,7 @@ const fixOrientationFromUrlOrBlobOrFile = (blob) => (
       {
         orientation: true,
         canvas: true,
+        crossOrigin: 'anonymous',
       },
     );
   })


### PR DESCRIPTION
This change fixes that issue: #514 .The third parameter for  blueimpLoadImage in blueimp-load-image need pass crossOrigin  to allow canvas use cross site image.