### PR TITLE
FetchError: <image link>, reason: socket hang up. After few thousand fetches

### DIFF
--- a/src/worker/node/loadImage.js
+++ b/src/worker/node/loadImage.js
@@ -3,6 +3,8 @@ const fs = require('fs');
 const fetch = require('node-fetch');
 const isURL = require('is-url');
 const jo = require('jpeg-autorotate');
+const controller = new AbortController()
+const signal = controller.signal
 
 const readFile = util.promisify(fs.readFile);
 
@@ -21,8 +23,11 @@ module.exports = async (image) => {
 
   if (typeof image === 'string') {
     if (isURL(image) || image.startsWith('moz-extension://') || image.startsWith('chrome-extension://') || image.startsWith('file://')) {
-      const resp = await fetch(image);
+      const resp = await fetch(image, { signal });
       data = await resp.arrayBuffer();
+
+      //Abort
+      controller.abort()
     } else if (/data:image\/([a-zA-Z]*);base64,([^"]*)/.test(image)) {
       data = Buffer.from(image.split(',')[1], 'base64');
     } else {


### PR DESCRIPTION
FetchError: request to https://cdn.discordapp.com/attachments/799677800722071552/865554600152530954/card.jpg failed, reason: socket hang up
 at ClientRequest.<anonymous> (/home/hideaki/Desktop/beta/node_modules/node-fetch/lib/index.js:1461:11)

I've been using your tesseract.js for months, Tessaract.js uses node fetch to fetch the image, But after few thousand fetching the above errors spams my console where in my program fails to fetch the damn image. But when I restart the mother node, everything works fine until few thousand fetches, I don't think there are rate limit issues as if it was the case then after the restart it should still fail to fetch.

From what I'm thinking could be something about the socket been open for too much time or been opened alot of times and not closed.. So I made some changes which kinda helped me.