### PR TITLE
Fix loadImage when the type is Blob

### DIFF
--- a/src/worker/browser/loadImage.js
+++ b/src/worker/browser/loadImage.js
@@ -78,7 +78,18 @@ const loadImage = async (image) => {
     }
   } else if (image instanceof File || image instanceof Blob) {
     let img = image;
-    if (!image.name.endsWith('.pbm')) {
+    let shouldFixOrientation;
+    if (image.name) {
+      // If name exist, check file extension isn't .pbm
+      shouldFixOrientation = !image.name.endsWith('.pbm');
+    } else if (image.type) {
+      // If empty name but type exist, check type isn't pbm
+      shouldFixOrientation = image.type !== 'image/x-portable-bitmap';
+    } else {
+      // Empty name and type
+      shouldFixOrientation = true;
+    }
+    if (shouldFixOrientation) {
       img = await fixOrientationFromUrlOrBlobOrFile(img);
     }
     data = await readFromBlobOrFile(img);

--- a/tests/recognize.test.js
+++ b/tests/recognize.test.js
@@ -181,4 +181,16 @@ describe('recognize()', () => {
       }).timeout(TIMEOUT)
     ));
   });
+
+  (IS_BROWSER ? describe : describe.skip)('should read image from Blob (browser only)', () => {
+    FORMATS.forEach((format) => (
+      it(`support ${format} format Blob`, async () => {
+        const url = `${IMAGE_PATH}/simple.${format}`;
+        const blob = await fetch(url).then((res) => res.blob());
+        await worker.initialize('eng');
+        const { data: { text } } = await worker.recognize(blob);
+        expect(text).to.be(SIMPLE_TEXT);
+      }).timeout(TIMEOUT)
+    ));
+  });
 });


### PR DESCRIPTION
For Blob doesn't have a `name` property natively, it not set explicitly, it will throw an error ` Cannot read property 'endsWith' of undefined`

So I am going to check the type of Blob, and this change is compatible if someone set name used old version.