### PR TITLE
Fix type error in `loadImage`

### DIFF
--- a/src/worker/browser/loadImage.js
+++ b/src/worker/browser/loadImage.js
@@ -78,7 +78,7 @@ const loadImage = async (image) => {
     }
   } else if (image instanceof File || image instanceof Blob) {
     let img = image;
-    if (!image.name.endsWith('.pbm')) {
+    if (image instance File && !image.name.endsWith('.pbm')) {
       img = await fixOrientationFromUrlOrBlobOrFile(img);
     }
     data = await readFromBlobOrFile(img);


### PR DESCRIPTION
If `image`'s type is Blob, an error will be thrown here