### PR TITLE
Fix for passing wrong arguments while calling fork function

### DIFF
--- a/src/worker/node/spawnWorker.js
+++ b/src/worker/node/spawnWorker.js
@@ -11,5 +11,5 @@ let debugPort = 9229;
  */
 module.exports = ({ workerPath }) => {
   debugPort += 1;
-  return fork(workerPath, { execArgv: [`--debug-port=${debugPort}`] });
+  return fork(workerPath, [], { execArgv: [`--debug-port=${debugPort}`] });
 };


### PR DESCRIPTION
Options should be passed as third parameter
ref: https://nodejs.org/api/child_process.html#child_processforkmodulepath-args-options