### PR TITLE
Upgraded file-type to fix security issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "babel-eslint": "^10.1.0",
     "bmp-js": "^0.1.0",
-    "file-type": "^12.4.1",
+    "file-type": "^16.5.4",
     "idb-keyval": "^3.2.0",
     "is-electron": "^2.2.0",
     "is-url": "^1.2.4",


### PR DESCRIPTION
Denial of Service (DoS) [High Severity][https://snyk.io/vuln/SNYK-JS-FILETYPE-2958042] in file-type@12.4.2
    introduced by tesseract.js@3.0.3 > file-type@12.4.2
  This issue was fixed in versions: 16.5.4, 17.1.3