### PR TITLE
Improve `loadImage` performance by between 20% and 100%

### DIFF
--- a/examples/browser/canvas.html
+++ b/examples/browser/canvas.html
@@ -1,0 +1,51 @@
+<html>
+
+<head>
+  <script src="/dist/tesseract.dev.js"></script>
+  <style>
+    .column {
+  float: left;
+  width: 20%;
+  padding: 5px;
+}
+
+  </style>
+</head>
+
+<body>
+  <img id="img">
+  <canvas id="canvas"></canvas>
+
+  <script defer>
+    const recognize = async () => {
+      console.log('starting')
+      const worker = await Tesseract.createWorker({
+        // corePath: '/tesseract-core-simd.wasm.js',
+        workerPath: "/dist/worker.dev.js"
+      });
+      await worker.loadLanguage('eng');
+      await worker.initialize('eng');
+      await worker.initialize();
+      console.log('worker initialized')
+
+      const canvas = document.getElementById('canvas');
+      const img = document.getElementById('img');
+      img.src = '../data/meditations.jpg';
+
+
+      img.onload = async () => {
+        console.log('image loaded')
+        canvas.width = img.width
+        canvas.height = img.height
+        canvas.getContext('2d').drawImage(img, 0, 0, img.width, img.height)
+        console.time('recognize from canvas');
+        const ret = await worker.recognize(canvas);
+        console.timeEnd('recognize from canvas');
+        console.log(ret.data.text)
+      };
+    }
+    recognize();
+  </script>
+</body>
+
+</html>

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -145,7 +145,7 @@ declare namespace Tesseract {
     BINARY = 2
   }
   type ImageLike = string | HTMLImageElement | HTMLCanvasElement | HTMLVideoElement
-    | CanvasRenderingContext2D | File | Blob | ImageData | Buffer;
+    | OffscreenCanvas | File | Blob | Buffer;
   interface Block {
     paragraphs: Paragraph[];
     text: string;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -144,8 +144,10 @@ declare namespace Tesseract {
     GREY = 1,
     BINARY = 2
   }
-  type ImageLike = string | HTMLImageElement | HTMLCanvasElement | HTMLVideoElement
-    | OffscreenCanvas | File | Blob | Buffer;
+  type ImageLike = string | HTMLImageElement | HTMLVideoElement
+  | HTMLCanvasElement | OffscreenCanvas | ImageData
+  | CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D
+  | File | Blob | Buffer;
   interface Block {
     paragraphs: Paragraph[];
     text: string;

--- a/src/worker/browser/loadImage.js
+++ b/src/worker/browser/loadImage.js
@@ -41,7 +41,7 @@ const imageDataToPBM = (imageData) => {
   header += `DEPTH ${DEPTH}\n`;
   header += `MAXVAL ${MAXVAL}\n`;
   header += `TUPLTYPE ${TUPLTYPE}\n`;
-  header += `ENDHDR\n`;
+  header += 'ENDHDR\n';
   const encoder = new TextEncoder();
   const binaryHeader = encoder.encode(header);
   const binary = new Uint8Array(binaryHeader.length + data.length);

--- a/src/worker/browser/loadImage.js
+++ b/src/worker/browser/loadImage.js
@@ -35,20 +35,20 @@ const imageDataToPBM = (imageData) => {
   const DEPTH = 4; // channels per pixel (RGBA = 4)
   const MAXVAL = 255; // range of each channel (0-255)
   const TUPLTYPE = 'RGB_ALPHA';
-  let header = 'P7\n'
-  header += `WIDTH ${width}\n`
-  header += `HEIGHT ${height}\n`
-  header += `DEPTH ${DEPTH}\n`
-  header += `MAXVAL ${MAXVAL}\n`
-  header += `TUPLTYPE ${TUPLTYPE}\n`
-  header += `ENDHDR\n`
+  let header = 'P7\n';
+  header += `WIDTH ${width}\n`;
+  header += `HEIGHT ${height}\n`;
+  header += `DEPTH ${DEPTH}\n`;
+  header += `MAXVAL ${MAXVAL}\n`;
+  header += `TUPLTYPE ${TUPLTYPE}\n`;
+  header += `ENDHDR\n`;
   const encoder = new TextEncoder();
   const binaryHeader = encoder.encode(header);
   const binary = new Uint8Array(binaryHeader.length + data.length);
   binary.set(binaryHeader);
   binary.set(data, binaryHeader.length);
-  return binary
-}
+  return binary;
+};
 
 /**
  * loadImage
@@ -74,14 +74,14 @@ const loadImage = async (image) => {
       data = await resp.arrayBuffer();
     }
   } else if (ImageData && image instanceof ImageData) {
-    data = imageDataToPBM(image)
+    data = imageDataToPBM(image);
   } else if (
     (CanvasRenderingContext2D && image instanceof CanvasRenderingContext2D)
     || (OffscreenCanvasRenderingContext2D && image instanceof OffscreenCanvasRenderingContext2D)) {
     const imageData = image.getImageData(0, 0, image.canvas.width, image.canvas.height);
-    data = await loadImage(imageData)
+    data = await loadImage(imageData);
   } else if (OffscreenCanvas && image instanceof OffscreenCanvas) {
-    data = await loadImage(image.getContext('2d'))
+    data = await loadImage(image.getContext('2d'));
   } else if (HTMLElement && image instanceof HTMLElement) {
     if (image.tagName === 'IMG') {
       data = await loadImage(image.src);
@@ -90,7 +90,7 @@ const loadImage = async (image) => {
       data = await loadImage(image.poster);
     }
     if (image.tagName === 'CANVAS') {
-      data = await loadImage(image.getContext('2d'))
+      data = await loadImage(image.getContext('2d'));
     }
   } else if (image instanceof File || image instanceof Blob) {
     data = await readFromBlobOrFile(image);

--- a/src/worker/browser/loadImage.js
+++ b/src/worker/browser/loadImage.js
@@ -45,7 +45,7 @@ const loadImage = async (image) => {
     }
   } else if (OffscreenCanvas && image instanceof OffscreenCanvas) {
     const blob = await image.convertToBlob({ type: 'image/bmp' });
-    data = await loadImage(blob)
+    data = await loadImage(blob);
   } else if (HTMLElement && image instanceof HTMLElement) {
     if (image.tagName === 'IMG') {
       data = await loadImage(image.src);

--- a/src/worker/browser/loadImage.js
+++ b/src/worker/browser/loadImage.js
@@ -43,7 +43,10 @@ const loadImage = async (image) => {
       const resp = await fetch(resolveURL(image));
       data = await resp.arrayBuffer();
     }
-  } else if (image instanceof HTMLElement) {
+  } else if (OffscreenCanvas && image instanceof OffscreenCanvas) {
+    const blob = await image.convertToBlob({ type: 'image/bmp' });
+    data = await loadImage(blob)
+  } else if (HTMLElement && image instanceof HTMLElement) {
     if (image.tagName === 'IMG') {
       data = await loadImage(image.src);
     }
@@ -55,7 +58,7 @@ const loadImage = async (image) => {
         image.toBlob(async (blob) => {
           data = await readFromBlobOrFile(blob);
           resolve();
-        });
+        }, { type: 'image/bmp' });
       });
     }
   } else if (image instanceof File || image instanceof Blob) {

--- a/src/worker/browser/loadImage.js
+++ b/src/worker/browser/loadImage.js
@@ -73,11 +73,15 @@ const loadImage = async (image) => {
       const resp = await fetch(resolveURL(image));
       data = await resp.arrayBuffer();
     }
+  } else if (ImageData && image instanceof ImageData) {
+    data = imageDataToPBM(image)
+  } else if (
+    (CanvasRenderingContext2D && image instanceof CanvasRenderingContext2D)
+    || (OffscreenCanvasRenderingContext2D && image instanceof OffscreenCanvasRenderingContext2D)) {
+    const imageData = image.getImageData(0, 0, image.canvas.width, image.canvas.height);
+    data = await loadImage(imageData)
   } else if (OffscreenCanvas && image instanceof OffscreenCanvas) {
-    const ctx = image.getContext('2d');
-    const imageData = ctx.getImageData(0, 0, image.width, image.height);
-    const pbm = imageDataToPBM(imageData);
-    data = pbm
+    data = await loadImage(image.getContext('2d'))
   } else if (HTMLElement && image instanceof HTMLElement) {
     if (image.tagName === 'IMG') {
       data = await loadImage(image.src);
@@ -86,10 +90,7 @@ const loadImage = async (image) => {
       data = await loadImage(image.poster);
     }
     if (image.tagName === 'CANVAS') {
-      const ctx = image.getContext('2d');
-      const imageData = ctx.getImageData(0, 0, image.width, image.height);
-      const pbm = imageDataToPBM(imageData);
-      data = pbm
+      data = await loadImage(image.getContext('2d'))
     }
   } else if (image instanceof File || image instanceof Blob) {
     data = await readFromBlobOrFile(image);


### PR DESCRIPTION
> TL;DR: `toBlob()` uses a relatively slow PNG encoder by default. A more uncompressed format like `image/bmp` is better suited for this use case.

## Canvas `.toBlob()` Benchmarks

I tested the performance of `toBlob` with 4 different lossless image formats:

- PNG (the current default, mime type `image/png`)
- RAW (an obscure mime type `image/x-dcraw`)
- TIF (`image/tif`)
- BMP (`image/bmp`)

There's a list of other potential mime types in [this thread](https://stackoverflow.com/a/47612661/16517800), however `image/bmp` is commonly supported and gave me the best results on average (see below).

### On a 1955x3036px Canvas image:

(Using pixel data from the `meditations.jpg` from the `tesseract.js` repo)

```txt
toPngBlob: 442.7470703125 ms
toRawBlob: 360.158935546875 ms
toTifBlob: 362.74609375 ms
toBmpBlob: 354.842041015625 ms
```

Average of **19.9%** speedup for BMP

### On a 100x100px Canvas image:

```txt
toPngBlob: 67.254150390625 ms
toRawBlob: 5.721923828125 ms
toTifBlob: 6.571044921875 ms
toBmpBlob: 1.542724609375 ms
```

Average of **97.7%** speedup for BMP (!!)

### Summary

The benefits of a faster image encoder are most noticeable on a small image size (100x100px or smaller). In addition, Tesseract.js can achieve truly lightning fast speeds on small inputs -- I'm seeing single-digit millisecond calls to `recognize` in some of my testing. It is plenty fast enough for fully realtime use cases when PNG encoding is avoided, since PNG encoding could take 4-5x longer than the actual text recognition at these sizes.

## Other changes

### Add support for `OffscreenCanvas`

This enables Tesseract.js to be started from inside another Web Worker, if desired (for example, after some image pre-processing which already happens off of the main thread). It uses the `OffscreenCanvas.convertToBlob` method which is an exact parallel of `Canvas.toBlob`.

Also, since `HTMLElement` is not defined inside a web worker, I added a check for that before using the `instanceof` method in order to avoid errors when calling `loadImage` from inside a Worker. 

### Update `ImageLike` types

`type ImageLike` currently contains two types for which there is no implementation:

- `CanvasRenderingContext2D`, which is not the intended way to read from `<canvas>` and would have no effect
- `ImageData` which similarly would need to be converted to a blob somehow, and it is easier to start from the `<canvas>` directly

Both options would currently result in runtime errors if they were used. So I've removed these two types, while also adding the `OffscreenCanvas` type as an option.

### (not implemented) Better support for `<video>`

Support for `<video>` sources could be improved, to obtain individual video frames instead of the static `video.poster` which is currently used. This would involve capturing video frames via `canvasContex.drawImage(video, 0, 0)` and then calling `canvas.toBlob()` like any other source. **However**, this would technically be a breaking change if anyone relies on the existing `video.poster` behavior, so I've left that out of this PR for now. I think reading video frames would be a more intuitive behavior than reading the video poster/thumbnail, but for now it would suffice for the user to implement that manually and maintain backwards compatibility.

## Checks

- [X] No breaking changes ✔
- [X] Eslint passing ✔
- [X] `npm run test:all` passes  ✔
- [X] Small change, only a few lines in 1 file + type definitions ✔
