### PR TITLE
Stop test traineddata being published

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
 tests
 .nyc_output
 .github
+/*.traineddata


### PR DESCRIPTION
Currently test `.traineddata` files are being published (`eng.traineddata` and `osd.traineddata`), bloating the install size to 36.8MB unpacked.

Stopping them being published drops the size to 2.8 MB, a 92.4% reduction!
