### PR TITLE
Stop dev tool config files being published to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,6 @@ tests
 .github
 /*.traineddata
 babel.config.json
+.eslintrc
+.gitpod.Dockerfile
+.gitpod.yml


### PR DESCRIPTION
ESLint and Gitpod are dev tools, so their config files are not needed by the published package.