### PR TITLE
Added filters to remove .traineddata files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,8 @@ node_modules/*
 yarn.lock
 tesseract.dev.js
 worker.dev.js
-/*.traineddata
-/examples/**/*.traineddata
+*.traineddata
+*.traineddata.gz
 .nyc_output
 dist/
 *.swp

--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,8 @@
 tests
 .nyc_output
 .github
-/*.traineddata
+*.traineddata
+*.traineddata.gz
 babel.config.json
 .eslintrc
 .gitpod.Dockerfile


### PR DESCRIPTION
Another unnecessary `.traineddata` file made it into a npm release.  Looks like the previous filters (#731) only ignored `.traineddata` files in specific directories.  I've edited to never include `.traineddata` or `.traineddata.gz` files. 