### PR TITLE
Support `OffscreenCanvas`

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -145,7 +145,7 @@ declare namespace Tesseract {
     BINARY = 2
   }
   type ImageLike = string | HTMLImageElement | HTMLCanvasElement | HTMLVideoElement
-    | CanvasRenderingContext2D | File | Blob | ImageData | Buffer;
+    | CanvasRenderingContext2D | File | Blob | ImageData | Buffer | OffscreenCanvas;
   interface Block {
     paragraphs: Paragraph[];
     text: string;

--- a/src/worker/browser/loadImage.js
+++ b/src/worker/browser/loadImage.js
@@ -43,7 +43,7 @@ const loadImage = async (image) => {
       const resp = await fetch(resolveURL(image));
       data = await resp.arrayBuffer();
     }
-  } else if (image instanceof HTMLElement) {
+  } else if (HTMLElement && image instanceof HTMLElement) {
     if (image.tagName === 'IMG') {
       data = await loadImage(image.src);
     }
@@ -58,6 +58,9 @@ const loadImage = async (image) => {
         });
       });
     }
+  } else if (OffscreenCanvas && image instanceof OffscreenCanvas) {
+    const blob = await image.convertToBlob();
+    data = await readFromBlobOrFile(blob);
   } else if (image instanceof File || image instanceof Blob) {
     data = await readFromBlobOrFile(image);
   }

--- a/src/worker/browser/loadImage.js
+++ b/src/worker/browser/loadImage.js
@@ -43,7 +43,7 @@ const loadImage = async (image) => {
       const resp = await fetch(resolveURL(image));
       data = await resp.arrayBuffer();
     }
-  } else if (HTMLElement && image instanceof HTMLElement) {
+  } else if (typeof HTMLElement !== 'undefined' && image instanceof HTMLElement) {
     if (image.tagName === 'IMG') {
       data = await loadImage(image.src);
     }
@@ -58,7 +58,7 @@ const loadImage = async (image) => {
         });
       });
     }
-  } else if (OffscreenCanvas && image instanceof OffscreenCanvas) {
+  } else if (typeof OffscreenCanvas !== 'undefined' && image instanceof OffscreenCanvas) {
     const blob = await image.convertToBlob();
     data = await readFromBlobOrFile(blob);
   } else if (image instanceof File || image instanceof Blob) {


### PR DESCRIPTION
- Handle `OffscreenCanvas` in browser `loadImage` function
- Update `ImageLike` type to include `OffscreenCanvas`
- Add unit test covering `recognize` from an `OffscreenCanvas`
- If `OffscreenCanvas` is not supported in the browser, the relevant branch in `loadImage` will be safely skipped over without any errors

Other references:
- <https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas>
- <https://caniuse.com/offscreencanvas>
- <https://caniuse.com/mdn-api_offscreencanvas_converttoblob>
- See also: #726 
