### PR TITLE
feat(index.d.ts): add type for logger args

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -43,6 +43,15 @@ declare namespace Tesseract {
     load_number_dawg: string
     load_bigram_dawg: string
   }
+  
+  type LoggerMessage = {
+    jobId: string
+    progress: number
+    status: string
+    userJobId: string
+    workerId: string
+  }
+  
   interface WorkerOptions {
     corePath: string
     langPath: string
@@ -52,7 +61,7 @@ declare namespace Tesseract {
     cacheMethod: string
     workerBlobURL: boolean
     gzip: boolean
-    logger: (arg: any) => void,
+    logger: (arg: LoggerMessage) => void,
     errorHandler: (arg: any) => void
   }
   interface WorkerParams {


### PR DESCRIPTION
 Adding new type to index.d.ts for logger args.

Fixes problems similar to 
<img width="669" alt="image" src="https://github.com/naptha/tesseract.js/assets/9071730/b8f119f3-32f8-4bf8-9422-8f2ac1c1daa3">
