### PR TITLE
Add project example to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ yarn add tesseract.js@3.0.3
 - With React: https://github.com/jeromewu/tesseract.js-react-app
 - Typescript: https://github.com/jeromewu/tesseract.js-typescript
 - Video Real-time Recognition: https://github.com/jeromewu/tesseract.js-video
+- Simple tool for converting PDF to text using OCR: https://github.com/racosa/pdf2text-ocr
 
 React Native is **not** supported as it does not support Webassembly. 
 


### PR DESCRIPTION
I've added a new project example to the README: [pdf2text-ocr](https://racosa.github.io/pdf2text-ocr/)

It's a simple tool for converting PDF to text using OCR that uses the latest version of Tesseract.js.

I've created it to help a friend who was getting gibberish when copying text from some PDFs at work.