### PR TITLE
Detect browsers in a Deno-compatible way

### DIFF
--- a/src/utils/getEnvironment.js
+++ b/src/utils/getEnvironment.js
@@ -7,7 +7,7 @@ module.exports = (key) => {
     env.type = 'webworker';
   } else if (isElectron()) {
     env.type = 'electron';
-  } else if (typeof window === 'object') {
+  } else if (typeof document === 'object') {
     env.type = 'browser';
   } else if (typeof process === 'object' && typeof require === 'function') {
     env.type = 'node';


### PR DESCRIPTION
I'm trying to use Tesseract.js in Deno, but currently I can't because of an incorrect runtime detection:

```ts
import { createWorker } from 'https://cdn.skypack.dev/tesseract.js@4.1.2?dts'

const worker = await createWorker()
// The above line throws the following error.
//
// error: Uncaught TypeError: Cannot read properties of undefined (reading 'href')
// const resolveURL = isBrowser ? (s) => new URL(s, window.location.href).href : (s) => s;
//                                                                  ^
//     at resolveURL (https://cdn.skypack.dev/-/tesseract.js@v4.1.2-tN0T6LCzDNBo5QPjk3os/dist=es2019,mode=imports/optimized/tesseractjs.js:313:66)
//     at https://cdn.skypack.dev/-/tesseract.js@v4.1.2-tN0T6LCzDNBo5QPjk3os/dist=es2019,mode=imports/optimized/tesseractjs.js:318:19
//     at Array.forEach (<anonymous>)
//     at resolvePaths (https://cdn.skypack.dev/-/tesseract.js@v4.1.2-tN0T6LCzDNBo5QPjk3os/dist=es2019,mode=imports/optimized/tesseractjs.js:316:42)
//     at createWorker (https://cdn.skypack.dev/-/tesseract.js@v4.1.2-tN0T6LCzDNBo5QPjk3os/dist=es2019,mode=imports/optimized/tesseractjs.js:606:7)
//     at file:///Users/ynkt/tmp/tesseract-deno/main.ts:3:22
```

Unlike Node.js, Deno has [`window` global](https://deno.land/api@v1.36.4?s=Window) so Tesseract.js misunderstands it's running in browsers. As [Remix's doc](https://remix.run/docs/en/1.19.3/pages/gotchas#typeof-window-checks) suggests, checks for `document` is preferred for this reason. This check is also backward compatible in other environments.

I don't claim first-class support for Deno (of course, I'd be happy if you do), but I just wish if I could use Tesseract.js in Deno in some way.

You can find similar PRs merged at other popular libraries like framer/motion#1522, TanStack/virtual#516, melt-ui/melt-ui#14, and chakra-ui/zag#694.