### PR TITLE
Use `node:` prefix to bypass require.cache call for builtins

### DIFF
--- a/benchmarks/node/speed-benchmark.js
+++ b/benchmarks/node/speed-benchmark.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-const path = require('path');
+const path = require('node:path');
 const { createWorker } = require('../../');
 
 (async () => {

--- a/examples/node/detect.js
+++ b/examples/node/detect.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-const path = require('path');
+const path = require('node:path');
 const Tesseract = require('../../');
 
 const [,, imagePath] = process.argv;

--- a/examples/node/download-pdf.js
+++ b/examples/node/download-pdf.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-const path = require('path');
-const fs = require('fs');
+const path = require('node:path');
+const fs = require('node:fs');
 const { createWorker } = require('../../');
 
 const [,, imagePath] = process.argv;

--- a/examples/node/image-processing.js
+++ b/examples/node/image-processing.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-const path = require('path');
-const fs = require('fs');
+const path = require('node:path');
+const fs = require('node:fs');
 const { createWorker } = require('../../');
 
 const [,, imagePath] = process.argv;

--- a/examples/node/recognize.js
+++ b/examples/node/recognize.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-const path = require('path');
+const path = require('node:path');
 const { createWorker } = require('../../');
 
 const [,, imagePath] = process.argv;

--- a/scripts/server.js
+++ b/scripts/server.js
@@ -1,7 +1,7 @@
 const webpack = require('webpack');
 const middleware = require('webpack-dev-middleware');
 const express = require('express');
-const path = require('path');
+const path = require('node:path');
 const cors = require('cors');
 const webpackConfig = require('./webpack.config.dev');
 

--- a/scripts/test-helper.js
+++ b/scripts/test-helper.js
@@ -1,7 +1,7 @@
 const constants = require('../tests/constants');
 global.expect = require('expect.js');
-global.fs = require('fs');
-global.path = require('path');
+global.fs = require('node:fs');
+global.path = require('node:path');
 global.Tesseract = require('../src');
 
 Object.keys(constants).forEach((key) => {

--- a/scripts/webpack.config.dev.js
+++ b/scripts/webpack.config.dev.js
@@ -1,4 +1,4 @@
-const path = require('path');
+const path = require('node:path');
 const webpack = require('webpack');
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 const common = require('./webpack.config.common');

--- a/scripts/webpack.config.prod.js
+++ b/scripts/webpack.config.prod.js
@@ -1,4 +1,4 @@
-const path = require('path');
+const path = require('node:path');
 const common = require('./webpack.config.common');
 const webpack = require('webpack');
 

--- a/src/worker-script/node/cache.js
+++ b/src/worker-script/node/cache.js
@@ -1,5 +1,5 @@
-const util = require('util');
-const fs = require('fs');
+const util = require('node:util');
+const fs = require('node:fs');
 
 module.exports = {
   readCache: util.promisify(fs.readFile),

--- a/src/worker-script/node/gunzip.js
+++ b/src/worker-script/node/gunzip.js
@@ -1,1 +1,1 @@
-module.exports = require('zlib').gunzipSync;
+module.exports = require('node:zlib').gunzipSync;

--- a/src/worker-script/node/index.js
+++ b/src/worker-script/node/index.js
@@ -9,7 +9,7 @@
  */
 
 const fetch = require('node-fetch');
-const { parentPort } = require('worker_threads');
+const { parentPort } = require('node:worker_threads');
 const worker = require('..');
 const getCore = require('./getCore');
 const gunzip = require('./gunzip');

--- a/src/worker/node/defaultOptions.js
+++ b/src/worker/node/defaultOptions.js
@@ -1,4 +1,4 @@
-const path = require('path');
+const path = require('node:path');
 const defaultOptions = require('../../constants/defaultOptions');
 
 /*

--- a/src/worker/node/loadImage.js
+++ b/src/worker/node/loadImage.js
@@ -1,5 +1,5 @@
-const util = require('util');
-const fs = require('fs');
+const util = require('node:util');
+const fs = require('node:fs');
 const fetch = require('node-fetch');
 const isURL = require('is-url');
 

--- a/src/worker/node/spawnWorker.js
+++ b/src/worker/node/spawnWorker.js
@@ -1,4 +1,4 @@
-const { Worker } = require('worker_threads');
+const { Worker } = require('node:worker_threads');
 
 /**
  * spawnWorker


### PR DESCRIPTION
Allows redundant `require.cache` calls to be bypassed for builtin modules, saving a few yoctoseconds.

See https://nodejs.org/api/modules.html#core-modules and [discussion in nodejs/node repo regarding why `require.cache` calls are redundant for builtins](https://github.com/nodejs/node/pull/37246/files#r588397158).