### PR TITLE
Added line size metrics to output per #906

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "node-fetch": "^2.6.9",
         "opencollective-postinstall": "^2.0.3",
         "regenerator-runtime": "^0.13.3",
-        "tesseract.js-core": "^5.0.0",
+        "tesseract.js-core": "^5.1.0",
         "wasm-feature-detect": "^1.2.11",
         "zlibjs": "^0.3.1"
       },
@@ -8664,9 +8664,9 @@
       }
     },
     "node_modules/tesseract.js-core": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/tesseract.js-core/-/tesseract.js-core-5.0.0.tgz",
-      "integrity": "sha512-lJur5LzjinW5VYMKlVNnBU2JPLpO+A9VqAYBeuV+ZgH0hKvsnm+536Yyp+/zRTBdLe7D6Kok0FN9g+TE4J8qGA=="
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/tesseract.js-core/-/tesseract.js-core-5.1.0.tgz",
+      "integrity": "sha512-D4gc5ET1DF/sDayF/eVmHgVGo7nqVC2e3d7uVgVOSAk4NOcmUqvJRTj8etqEmI/2390ZkXCRiDMxTD1RFYyp1g=="
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",
@@ -16062,9 +16062,9 @@
       }
     },
     "tesseract.js-core": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/tesseract.js-core/-/tesseract.js-core-5.0.0.tgz",
-      "integrity": "sha512-lJur5LzjinW5VYMKlVNnBU2JPLpO+A9VqAYBeuV+ZgH0hKvsnm+536Yyp+/zRTBdLe7D6Kok0FN9g+TE4J8qGA=="
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/tesseract.js-core/-/tesseract.js-core-5.1.0.tgz",
+      "integrity": "sha512-D4gc5ET1DF/sDayF/eVmHgVGo7nqVC2e3d7uVgVOSAk4NOcmUqvJRTj8etqEmI/2390ZkXCRiDMxTD1RFYyp1g=="
     },
     "test-exclude": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "node-fetch": "^2.6.9",
     "opencollective-postinstall": "^2.0.3",
     "regenerator-runtime": "^0.13.3",
-    "tesseract.js-core": "^5.0.0",
+    "tesseract.js-core": "^5.1.0",
     "wasm-feature-detect": "^1.2.11",
     "zlibjs": "^0.3.1"
   },

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -178,6 +178,11 @@ declare namespace Tesseract {
     y1: number;
     has_baseline: boolean;
   }
+  interface RowAttributes {
+    ascenders: number;
+    descenders: number;
+    row_height: number;
+  }
   interface Bbox {
     x0: number;
     y0: number;
@@ -189,6 +194,7 @@ declare namespace Tesseract {
     text: string;
     confidence: number;
     baseline: Baseline;
+    rowAttributes: RowAttributes
     bbox: Bbox;
     paragraph: Paragraph;
     block: Block;

--- a/src/worker-script/utils/dump.js
+++ b/src/worker-script/utils/dump.js
@@ -126,11 +126,22 @@ module.exports = (TessModule, api, output, options) => {
         block.paragraphs.push(para);
       }
       if (ri.IsAtBeginningOf(RIL_TEXTLINE)) {
+        // getRowAttributes was added in a recent minor version of Tesseract.js-core,
+        // so we need to check if it exists before calling it.
+        // This can be removed in the next major version (v6).
+        let rowAttributes;
+        if (ri.getRowAttributes) {
+          rowAttributes = ri.getRowAttributes();
+          // Descenders is reported as a negative within Tesseract internally so we need to flip it.
+          // The positive version is intuitive, and matches what is reported in the hOCR output.
+          rowAttributes.descenders *= -1;
+        }
         textline = {
           words: [],
           text: !options.skipRecognition ? ri.GetUTF8Text(RIL_TEXTLINE) : null,
           confidence: !options.skipRecognition ? ri.Confidence(RIL_TEXTLINE) : null,
           baseline: ri.getBaseline(RIL_TEXTLINE),
+          rowAttributes,
           bbox: ri.getBoundingBox(RIL_TEXTLINE),
         };
         para.lines.push(textline);


### PR DESCRIPTION
Resolves #906 by adding `rowAttributes` object to output, which contains `ascenders`/`descenders`/`row_height` metrics.