### PR TITLE
Remove ImageData from ImageLike

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -157,7 +157,7 @@ declare namespace Tesseract {
     BINARY = 2
   }
   type ImageLike = string | HTMLImageElement | HTMLCanvasElement | HTMLVideoElement
-    | CanvasRenderingContext2D | File | Blob | ImageData | Buffer | OffscreenCanvas;
+    | CanvasRenderingContext2D | File | Blob | Buffer | OffscreenCanvas;
   interface Block {
     paragraphs: Paragraph[];
     text: string;


### PR DESCRIPTION
This PR removes the `ImageData` type from `ImageLike`, as `ImageData` is not supported (as far as I can tell - it was temporarily supported, but then it was rolled back in #610).

For the record, this is the error I got when trying to use `ImageData`:
![image](https://github.com/user-attachments/assets/fcdf84e4-88ec-4b3b-a8a9-e4d0a7cf95c5)
