### PR TITLE
Remove unused catch binding

### DIFF
--- a/src/worker-script/index.js
+++ b/src/worker-script/index.js
@@ -118,7 +118,7 @@ res) => {
         throw Error('Not found in cache');
       }
     // Attempt to fetch new .traineddata file
-    } catch (e) {
+    } catch {
       newData = true;
       log(`[${workerId}]: Load ${lang}.traineddata from ${langPath}`);
       if (typeof _lang === 'string') {


### PR DESCRIPTION
The `e` variable is unused, so this is a tad cleaner.