### PR TITLE
Limited use of node-fetch package to Node.js versions that require it

### DIFF
--- a/src/worker-script/node/index.js
+++ b/src/worker-script/node/index.js
@@ -9,8 +9,8 @@
  * @author Guillermo Webster <gui@mit.edu>
  * @author Jerome Wu <jeromewus@gmail.com>
  */
-
-const fetch = require('node-fetch');
+// Use built-in fetch if available, otherwise fallback to node-fetch
+const fetch = global.fetch || require('node-fetch');
 const { parentPort } = require('worker_threads');
 const worker = require('..');
 const getCore = require('./getCore');

--- a/src/worker/node/loadImage.js
+++ b/src/worker/node/loadImage.js
@@ -2,7 +2,8 @@
 
 const util = require('util');
 const fs = require('fs');
-const fetch = require('node-fetch');
+// Use built-in fetch if available, otherwise fallback to node-fetch
+const fetch = global.fetch || require('node-fetch');
 const isURL = require('is-url');
 
 const readFile = util.promisify(fs.readFile);


### PR DESCRIPTION
We currently use a years-old version of the `node-fetch` package for implementing `fetch` in Node.js, despite Node.js having supported `fetch` natively for several years (and in *all* non-depreciated versions).  This results in depreciation messages being printed, which several users have complained about (see #876).  This PR updates the `require` statement to only use the `node-fetch` implementation of `fetch` when it is actually necessary. 