### PR TITLE
Add GIF format to document

### DIFF
--- a/docs/image-format.md
+++ b/docs/image-format.md
@@ -2,7 +2,7 @@
 
 The main Tesseract.js functions (ex. recognize, detect) take an `image` parameter.  The image formats and data types supported are listed below. 
 
-Support Image Formats: **bmp, jpg, png, pbm, webp, gif**
+Support Image Formats: **bmp, jpg, png, pbm, webp, gif \[non-animated\]**.
 
 For browser and Node, supported data types are:
  - string with base64 encoded image (fits `data:image\/([a-zA-Z]*);base64,([^"]*)` regexp)


### PR DESCRIPTION
Add GIF format to `docs/image-format.md tests/constants.mjs` according to the below:

- https://github.com/naptha/tesseract.js/blob/master/tests/constants.mjs#L17
- https://tesseract-ocr.github.io/tessdoc/InputFormats.html

I tested to recognize a GIF image!
https://tesseract.projectnaptha.com/
[example.gif](https://github.com/user-attachments/assets/e75e4d11-8033-4185-877b-9d7286150dcf)
[![Image from Gyazo](https://i.gyazo.com/0f9d62d9d3ed6576d3f5ec094f4df52d.png)](https://gyazo.com/0f9d62d9d3ed6576d3f5ec094f4df52d)
