### PR TITLE
Fixed types per #1033

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -161,7 +161,6 @@ declare namespace Tesseract {
     y0: number;
     x1: number;
     y1: number;
-    has_baseline: boolean;
   }
   interface RowAttributes {
     ascenders: number;


### PR DESCRIPTION
The `has_baseline` property was removed in the v5 -> v6 update, however the types were never updated.  This patches the types.  Resolves #1033.