### PR TITLE
Fix: Correct OEM condition check in getCore.js (Issue #1034)

### DIFF
--- a/src/worker-script/node/getCore.js
+++ b/src/worker-script/node/getCore.js
@@ -20,8 +20,7 @@ module.exports = async (oem, _, res) => {
       } else {
         TesseractCore = require('tesseract.js-core/tesseract-core-simd');
       }
-    } else if ([OEM.DEFAULT, OEM.LSTM_ONLY].includes(oem)) {
-      TesseractCore = require('tesseract.js-core/tesseract-core-lstm');
+} else if (![OEM.DEFAULT, OEM.LSTM_ONLY].includes(oem)) {      TesseractCore = require('tesseract.js-core/tesseract-core-lstm');
     } else {
       TesseractCore = require('tesseract.js-core/tesseract-core');
     }


### PR DESCRIPTION
…dition on line 23 of getCore.js where the else if statement was checking for the same condition twice. Changed from checking if OEM is in [DEFAULT, LSTM_ONLY] to checking if it is NOT in that array (negated condition) to properly handle legacy model loading.

Fixed line 23 condition that was checking for the same OEM values twice. Changed from: } else if ([OEM.DEFAULT, OEM.LSTM_ONLY].includes(oem)) { Changed to: } else if (![OEM.DEFAULT, OEM.LSTM_ONLY].includes(oem)) {

This ensures legacy models (TESSERACT_ONLY, TESSERACT_LSTM_COMBINED) are loaded correctly when SIMD is not supported.

Fixes issue #1034